### PR TITLE
Updated get_contribution method to take ID instead of player name

### DIFF
--- a/SQL.py
+++ b/SQL.py
@@ -407,24 +407,22 @@ def get_report_stats():
 
 # TODO: please clean, add count in query
 
-def get_contributions(contributor, manual_report=None):
+def get_contributions(contributor_id, manual_report=None):
     
     query = '''
         SELECT DISTINCT
-            rptr.name reporter_name,
             rptd.name reported_name,
             rptd.confirmed_ban,
             rptd.possible_ban,
             rptd.confirmed_player
         from Reports rpts
-        inner join Players rptr on(rpts.reportingID = rptr.id)
         inner join Players rptd on(rpts.reportedID = rptd.id)
         WHERE 1=1
-            and rptr.name = :contributor
+            and rpts.id = :contributor_id
     '''
 
     params = {
-        "contributor": contributor
+        "contributor_id": contributor_id
     }
 
     if (manual_report):

--- a/plugin/plugin_stats.py
+++ b/plugin/plugin_stats.py
@@ -3,19 +3,20 @@ import SQL
 
 plugin_stats = Blueprint('plugin_stats', __name__, template_folder='templates')
 
-@plugin_stats.route('/stats/contributions/<contributor_id>', methods=['GET'])
-@plugin_stats.route('/<version>/stats/contributions/<contributor_id>', methods=['GET'])
-def get_contributions(version=None, contributor_id=""):
+@plugin_stats.route('/stats/contributions/<contributor>', methods=['GET'])
+@plugin_stats.route('/<version>/stats/contributions/<contributor>', methods=['GET'])
+def get_contributions(version=None, contributor=""):
 
-    if(contributor_id==""):
+    if(contributor==""):
         return "<h1>400</h1><p>You must include a Runescape Name in your query.</p>", 400
 
-    else:
-        try:
-            passive_contributions = SQL.get_contributions(contributor_id, manual_report=0)
-            manual_contributions = SQL.get_contributions(contributor_id, manual_report=1)
-        except Exception as e:
-            print(e)
+        if(isinstance(contributor, int)):
+            contributor_id = int(contributor)
+        else:
+            contributor_id = SQL.get_player(contributor).id
+
+        passive_contributions = SQL.get_contributions(contributor_id, manual_report=0)
+        manual_contributions = SQL.get_contributions(contributor_id, manual_report=1)
 
         passive_reports = len(passive_contributions)
         passive_bans = 0

--- a/plugin/plugin_stats.py
+++ b/plugin/plugin_stats.py
@@ -11,7 +11,7 @@ def get_contributions(version=None, contributor=""):
         return "<h1>400</h1><p>You must include a Runescape Name in your query.</p>", 400
 
         if(isinstance(contributor, int)):
-            contributor_id = int(contributor)
+            contributor_id = contributor
         else:
             contributor_id = SQL.get_player(contributor).id
 

--- a/plugin/plugin_stats.py
+++ b/plugin/plugin_stats.py
@@ -3,17 +3,17 @@ import SQL
 
 plugin_stats = Blueprint('plugin_stats', __name__, template_folder='templates')
 
-@plugin_stats.route('/stats/contributions/<contributor>', methods=['GET'])
-@plugin_stats.route('/<version>/stats/contributions/<contributor>', methods=['GET'])
-def get_contributions(version=None, contributor=""):
+@plugin_stats.route('/stats/contributions/<contributor_id>', methods=['GET'])
+@plugin_stats.route('/<version>/stats/contributions/<contributor_id>', methods=['GET'])
+def get_contributions(version=None, contributor_id=""):
 
-    if(contributor==""):
+    if(contributor_id==""):
         return "<h1>400</h1><p>You must include a Runescape Name in your query.</p>", 400
 
     else:
         try:
-            passive_contributions = SQL.get_contributions(contributor, manual_report=0)
-            manual_contributions = SQL.get_contributions(contributor, manual_report=1)
+            passive_contributions = SQL.get_contributions(contributor_id, manual_report=0)
+            manual_contributions = SQL.get_contributions(contributor_id, manual_report=1)
         except Exception as e:
             print(e)
 


### PR DESCRIPTION
The idea behind this change is that using an ID instead of a player name allows the query to involve one less join statement. This should help improvement the efficiency of this method, as currently it is quite slow. It will probably require the plugin and discord bot to make an additional API call to convert player name -> player ID. However, there should be net gain anyway.