### PR TITLE
Update detect.py

### DIFF
--- a/plugin/detect.py
+++ b/plugin/detect.py
@@ -111,6 +111,6 @@ def post_detect(version=None, manual_detect=0):
     detections = df.to_dict('records')
 
     Config.debug(f'      Received detections: DF shape: {df.shape}')
-    Config.sched.add_job(insync_detect ,args=[detections, manual_detect], replace_existing=False, name='detect')
+    Config.sched.add_job(insync_detect ,args=[detections, manual_detect], replace_existing=False, name='detect', misfire_grace_time=None)
 
     return jsonify({'OK': 'OK'})


### PR DESCRIPTION
misfire_grace_time: seconds after the designated runtime that the job is still allowed to be run (or ``None`` to allow the job to run no matter how late it is)