### PR TITLE
add cors support to api

### DIFF
--- a/api/Config.py
+++ b/api/Config.py
@@ -4,6 +4,7 @@ import sys
 
 from dotenv import find_dotenv, load_dotenv
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
@@ -19,6 +20,21 @@ token = os.environ.get('token')
 
 # create application
 app = FastAPI()
+
+origins = [
+    "http://osrsbotdetector.com/",
+    "https://osrsbotdetector.com/",
+    "http://localhost",
+    "http://localhost:8080",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # setup logging
 file_handler = logging.FileHandler(filename="logs/error.log", mode='a')


### PR DESCRIPTION
Currently, [osrsbotdetector.com](http://osrsbotdetector.com/) throws a CORS error when requesting from API endpoints. This PR adds support for the website clients to consume API endpoints

Followed https://fastapi.tiangolo.com/tutorial/cors/