### PR TITLE
Use normalized name

### DIFF
--- a/api/routers/legacy.py
+++ b/api/routers/legacy.py
@@ -165,6 +165,7 @@ async def sql_insert_report(data):
 
 
 async def sql_get_contributions(contributors: List):
+
     query = ("""
         SELECT
             rs.manual_detect as detect,
@@ -180,7 +181,7 @@ async def sql_get_contributions(contributors: List):
     """)
 
     param = {
-        "contributors": contributors
+        "contributors": await jagexify_names_list(contributors)
     }
 
     output = []
@@ -455,6 +456,10 @@ async def is_valid_rsn(rsn):
 # TODO: normalize name
 async def to_jagex_name(name: str) -> str:
     return name.lower().replace('_', ' ').replace('-',' ').strip()
+
+
+async def jagexify_names_list(names: List[str]) -> List[str]:
+    return  [await to_jagex_name(n) for n in names if await is_valid_rsn(n)]
     
 
 async def custom_hiscore(detection):
@@ -664,7 +669,7 @@ async def detect(detections, manual_detect):
     names.extend(df['reporter'].unique())
 
     # 1.1) Normalize and validate all names
-    clean_names = [await to_jagex_name(name) for name in names if await is_valid_rsn(name)]
+    clean_names = await jagexify_names_list(names)
 
     # 2) Get IDs for all unique names
     data = await sql_select_players(clean_names)

--- a/api/routers/legacy.py
+++ b/api/routers/legacy.py
@@ -176,7 +176,7 @@ async def sql_get_contributions(contributors: List):
         JOIN Players as pl on (pl.id = rs.reportingID)
         join Players as ban on (ban.id = rs.reportedID)
         WHERE 1=1
-            AND pl.name in :contributors
+            AND pl.normalized_name in :contributors
     """)
 
     param = {
@@ -775,7 +775,9 @@ async def receive_plugin_feedback(feedback: Feedback, version: str = None):
     feedback_params = feedback.dict()
     player_name = feedback_params.pop("player_name")
 
-    voter_data = await execute_sql(sql=f"select * from Players where name = :player_name", param={"player_name": player_name})
+    normalized_name = to_jagex_name(player_name)
+
+    voter_data = await execute_sql(sql=f"select * from Players where normalized_name = :normalized_name", param={"normalized_name": normalized_name})
 
     if voter_data is None:
         voter_data = await sql_insert_player(player_name)

--- a/api/routers/legacy_debug.py
+++ b/api/routers/legacy_debug.py
@@ -142,7 +142,6 @@ async def detect(detections:List[detection], manual_detect:int) -> None:
     # 3.1) Get those players' IDs from step 3
     if new_names:
         param = [{"name": name, "nname":name} for name in new_names]
-        print(param)
         await batch_function(sql_insert_player, param)
 
         data.extend(await sql_select_players(new_names))

--- a/api/routers/legacy_debug.py
+++ b/api/routers/legacy_debug.py
@@ -225,7 +225,7 @@ async def sql_get_feedback_submissions(voters: List):
         FROM PredictionsFeedback 
         JOIN Players ON Players.id = PredictionsFeedback.voter_id
         WHERE 1=1
-            AND Players.name IN :voters
+            AND Players.normalized_name IN :voters
      '''
 
     params = {

--- a/api/routers/legacy_debug.py
+++ b/api/routers/legacy_debug.py
@@ -19,6 +19,7 @@ async def run_in_process(fn, *args):
     loop = asyncio.get_event_loop()
     return await loop.run_in_executor(app.state.executor, fn, *args)
 
+
 '''DETECT ROUTE'''
 class equipment(BaseModel):
     HEAD: Optional[int]
@@ -30,6 +31,7 @@ class equipment(BaseModel):
     HANDS: Optional[int]
     WEAPON: Optional[int]
     SHIELD: Optional[int]
+
 
 class detection(BaseModel):
     reporter: str
@@ -45,13 +47,16 @@ class detection(BaseModel):
     equipment: Optional[equipment]
     equipment_ge: Optional[int]
 
+
 async def is_valid_rsn(rsn: str) -> bool:
     return re.fullmatch('[\w\d\s_-]{1,13}', rsn)
+
 
 async def to_jagex_name(name: str) -> str:
     return name.lower().replace('_', ' ').replace('-',' ').strip()
 
-async def sql_select_players(names: List):
+
+async def sql_select_players(names):
     names = [await to_jagex_name(n)for n in names]
     sql = "SELECT * FROM Players WHERE normalized_name in :names"
     param = {"names": names}
@@ -59,11 +64,12 @@ async def sql_select_players(names: List):
     
     return [] if not data else data.rows2dict()
 
+
 async def parse_detection(data:dict) -> dict:
     gmt = time.gmtime(data['ts'])
     human_time = time.strftime('%Y-%m-%d %H:%M:%S', gmt)
 
-    equipment = data.get('equipment')
+    equipment = data.get('equipment', {})
 
     param = {
         'reportedID': data.get('id'),
@@ -86,13 +92,15 @@ async def parse_detection(data:dict) -> dict:
         'equip_hands_id': equipment.get('HANDS'),
         'equip_weapon_id': equipment.get('WEAPON'),
         'equip_shield_id': equipment.get('SHIELD'),
-        'equip_ge_value': data.get('equipment_ge')
+        'equip_ge_value': data.get('equipment_ge', 0)
     }
     return param
+
 
 async def sql_insert_player(param):
     sql = "insert ignore into Players (name, normalized_name) values (:name, :nname)"
     await execute_sql(sql, param)
+
 
 async def sql_insert_report(param):
     params = list(param[0].keys())
@@ -101,6 +109,7 @@ async def sql_insert_report(param):
 
     sql = f'insert ignore into Reports ({columns}) values ({values})'
     await execute_sql(sql, param)
+
 
 async def detect(detections:List[detection], manual_detect:int) -> None:
     manual_detect = 0 if int(manual_detect) == 0 else 1
@@ -133,6 +142,7 @@ async def detect(detections:List[detection], manual_detect:int) -> None:
     # 3.1) Get those players' IDs from step 3
     if new_names:
         param = [{"name": name, "nname":name} for name in new_names]
+        print(param)
         await batch_function(sql_insert_player, param)
 
         data.extend(await sql_select_players(new_names))
@@ -142,7 +152,9 @@ async def detect(detections:List[detection], manual_detect:int) -> None:
     df_names = pd.DataFrame(data)
     df = df.merge(df_names, left_on="reported", right_on="name")
 
-    df["reporter_id"]  = df_names.query(f"name == {df['reporter'].unique()}")['id'].to_list()[0]
+    reporter = [await to_jagex_name(n) for n in df['reporter'].unique()]
+    df["reporter_id"] = df_names.query(f"name == {reporter}")['id'].to_list()[0]
+
     df['manual_detect'] = manual_detect
     # 4.2) parse data to param
     data = df.to_dict('records')
@@ -151,8 +163,10 @@ async def detect(detections:List[detection], manual_detect:int) -> None:
     # 4.3) parse query
     await batch_function(sql_insert_report, param)
 
+
 async def offload_detect(detections:List[detection], manual_detect:int) -> None:
     await run_in_process(detect, detections, manual_detect)
+
 
 @router.post('/{version}/plugin/detect/{manual_detect}', tags=["Legacy"])
 async def post_detect(
@@ -165,9 +179,11 @@ async def post_detect(
     )
     return {'ok':'ok'}
 
+
 '''CONTRIBUTIONS ROUTE'''
 class contributor(BaseModel):
     name: str
+
 
 async def sql_get_contributions(contributors: List):
     query = ("""
@@ -181,7 +197,7 @@ async def sql_get_contributions(contributors: List):
         JOIN Players as pl on (pl.id = rs.reportingID)
         join Players as ban on (ban.id = rs.reportedID)
         WHERE 1=1
-            AND pl.name in :contributors
+            AND pl.normalized_name in :contributors
     """)
 
     param = {
@@ -201,6 +217,7 @@ async def sql_get_contributions(contributors: List):
 
     return output
 
+
 async def sql_get_feedback_submissions(voters: List):
     sql = '''
         SELECT 
@@ -217,6 +234,7 @@ async def sql_get_feedback_submissions(voters: List):
 
     data = await execute_sql(sql, param=params, debug=False, row_count=100_000_000)
     return data.rows2dict()
+
 
 async def parse_contributors(contributors, version=None, add_patron_stats:bool=False):
     contributions = await sql_get_contributions(contributors)
@@ -319,13 +337,13 @@ async def get_contributions(contributors: List[contributor], token:str=None):
         await verify_token(token, verification='verify_players')
         add_patron_stats = True
         
-    contributors = [d.__dict__['name'] for d in contributors]
+    accounts = [await to_jagex_name(d.__dict__['name']) for d in contributors]
     
-    data = await parse_contributors(contributors, version=None, add_patron_stats=add_patron_stats)
+    data = await parse_contributors(accounts, version=None, add_patron_stats=add_patron_stats)
     return data
 
 
 @router.get('/{version}/stats/contributions/{contributor}', tags=["Legacy"])
 async def get_contributions_url(contributor: str, version: str):
-    data = await parse_contributors([contributor], version=version)
+    data = await parse_contributors([await to_jagex_name(contributor)], version=version)
     return data

--- a/api/routers/legacy_debug.py
+++ b/api/routers/legacy_debug.py
@@ -56,6 +56,10 @@ async def to_jagex_name(name: str) -> str:
     return name.lower().replace('_', ' ').replace('-',' ').strip()
 
 
+async def jagexify_names_list(names: List[str]) -> List[str]:
+    return  [await to_jagex_name(n) for n in names if await is_valid_rsn(n)]
+
+
 async def sql_select_players(names):
     names = [await to_jagex_name(n)for n in names]
     sql = "SELECT * FROM Players WHERE normalized_name in :names"
@@ -185,6 +189,7 @@ class contributor(BaseModel):
 
 
 async def sql_get_contributions(contributors: List):
+
     query = ("""
         SELECT
             ifnull(rs.manual_detect,0) as detect,
@@ -200,7 +205,7 @@ async def sql_get_contributions(contributors: List):
     """)
 
     param = {
-        "contributors": contributors
+        "contributors": await jagexify_names_list(contributors)
     }
 
     output = []


### PR DESCRIPTION
Brand new players are having their name and normalized_name values being set to the same string. However, many of our SELECT queries were set to select rows where the name column matches the RSN of a user as it appears on game (upper case letters, -, and _ included) which meant that users with the aforementioned characters in their name could not submit sightings, send feedback, or get their contribution stats.

This PR aims to resolve those issues.

We will want to remove the normalized_name column and instead use the name column (with normalized name values), but first we need to remove duplicate entries and then normalize the column's values. By pointing everything to normalized_name it gives us an opportunity to make these changes without downtime.