### PR TITLE
mute error, documentation & bug fix

### DIFF
--- a/api/Config.py
+++ b/api/Config.py
@@ -91,7 +91,5 @@ logging.getLogger("uvicorn.error").propagate = False
 
 
 # https://github.com/aio-libs/aiomysql/issues/103
-
-# Suppress warnings only for aiomysql, all other modules can send warnings
-warnings.filterwarnings('ignore', module=r"aiomysql")
-warnings.filterwarnings('ignore', module=r"asyncmy")
+# https://github.com/coleifer/peewee/issues/2229
+warnings.filterwarnings('ignore', '.*Duplicate entry.*')

--- a/api/database/functions.py
+++ b/api/database/functions.py
@@ -168,6 +168,9 @@ async def verify_token(token: str, verification: str, route: str = None) -> bool
 
 
 async def batch_function(function, data, batch_size=100):
+    '''
+        smaller transactions, can reduce locks, but individual transaction, can cause connection pool overflow
+    '''
     batches = []
     for i in range(0, len(data), batch_size):
         logger.debug({"batch": {f'{function.__name__}':f'{i}/{len(data)}'}})

--- a/api/routers/scraper.py
+++ b/api/routers/scraper.py
@@ -137,43 +137,44 @@ async def handle_lock(function, data):
     await function(data)
 
 
-async def sqla_update_player(players):
+async def sqla_update_player(players: List):
     logger.debug({"message":f'update players: {len(players)=}'})
 
-    async with get_session(EngineType.PLAYERDATA) as session:
-        try:
+    dbplayer = players.copy()
+    try:
+        async with get_session(EngineType.PLAYERDATA) as session:
             for player in players:
                 player_id = player.get('id')
                 sql = update(dbPlayer).values(player).where(dbPlayer.id==player_id)
                 await session.execute(sql, player)
-            await session.commit()
-        except (OperationalError, InternalError) as e:
-            await handle_lock(sqla_update_player, players)
-        finally:
-            await session.close()
+                await session.commit()
+                dbplayer.remove(player)
+    except (OperationalError, InternalError) as e:
+        await handle_lock(sqla_update_player, dbplayer)
     return
 
 async def sqla_insert_hiscore(hiscores:List):
     logger.debug({"message":f'insert hiscores: {len(hiscores)=}'})
 
     sql = insert(playerHiscoreData).prefix_with('ignore')
-    
-    async with get_session(EngineType.PLAYERDATA) as session:
-        try:
-            await session.execute(sql, hiscores)
-            await session.commit()
-        except (OperationalError, InternalError) as e:
-            await handle_lock(sqla_insert_hiscore, hiscores)
-        finally:
-            await session.close()
+    dbhiscores = hiscores.copy()
+    try:
+        async with get_session(EngineType.PLAYERDATA) as session:
+            for hiscore in hiscores:
+                await session.execute(sql, hiscore)
+                await session.commit()
+                dbhiscores.remove(hiscore)
+    except (OperationalError, InternalError) as e:
+        await handle_lock(sqla_insert_hiscore, dbhiscores)
+
     return
 
 @router.post("/scraper/hiscores/{token}", tags=["Business"])
-async def receive_scraper_data(token, data: List[scraper], hiscores_tasks: BackgroundTasks):
+async def receive_scraper_data(token, data: List[scraper]):
     await verify_token(token, verification='verify_ban', route='[POST]/scraper/hiscores/token')
     # background task will cause lots of duplicates
-    hiscores_tasks.add_task(post_hiscores_to_db, data)
-    return {'ok': f'{len(data)} records to be inserted.'}
+    asyncio.create_task(post_hiscores_to_db(data))
+    return {'detail': f'{len(data)} records to be inserted.'}
 
 
 async def post_hiscores_to_db(data: List[scraper]):
@@ -197,5 +198,5 @@ async def post_hiscores_to_db(data: List[scraper]):
     # batchwise insert & update
     await batch_function(sqla_insert_hiscore, hiscores, batch_size=1000)
     await sqla_update_player(players)
-    return {'ok':'ok'}
+    return
   


### PR DESCRIPTION
Config, muted duplicate warning (return from the db)
functions added some "documenation" .
scraper:
instead of background task, asyncio.create_task.
try except outside of the session, (session should close when an error occurs, double closing makes the reference count negative => garbage collector wants to clean up the connection)
commit after each insert, but keep track of what is inserted, so in case of a retry we don't have to retry everything, only what has not been done yet