### PR TITLE
Replace Hard-coded Route Logging Strings

### DIFF
--- a/api/routers/feedback.py
+++ b/api/routers/feedback.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.database.functions import (EngineType, sqlalchemy_result,
                                     verify_token)
 from api.database.models import Player, PredictionsFeedback
-from api.utils.logging_helpers import build_route_log_string
+from api.utils import logging_helpers
 from fastapi import APIRouter, HTTPException, Query, status, Request
 from pydantic import BaseModel
 from pydantic.fields import Field
@@ -41,7 +41,11 @@ async def get_feedback(
     Get player feedback of a player
     """
     # verify token
-    await verify_token(token, verification="verify_ban", route=build_route_log_string(request))
+    await verify_token(
+        token,
+        verification="verify_ban",
+        route=logging_helpers.build_route_log_string(request)
+    )
 
 
     # query

--- a/api/routers/feedback.py
+++ b/api/routers/feedback.py
@@ -6,7 +6,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.database.functions import (EngineType, sqlalchemy_result,
                                     verify_token)
 from api.database.models import Player, PredictionsFeedback
-from fastapi import APIRouter, HTTPException, Query, status
+from api.utils.logging_helpers import build_route_log_string
+from fastapi import APIRouter, HTTPException, Query, status, Request
 from pydantic import BaseModel
 from pydantic.fields import Field
 from sqlalchemy import func, select
@@ -32,6 +33,7 @@ router = APIRouter()
 async def get_feedback(
     token: str,
     name: str,
+    request: Request,
     row_count: Optional[int] = Query(100_000, ge=1, le=100_000),
     page: Optional[int] = Query(1, ge=1),
 ):
@@ -39,7 +41,7 @@ async def get_feedback(
     Get player feedback of a player
     """
     # verify token
-    await verify_token(token, verification="verify_ban", route="[GET]/v1/feedback")
+    await verify_token(token, verification="verify_ban", route=build_route_log_string(request))
 
 
     # query

--- a/api/routers/hiscore.py
+++ b/api/routers/hiscore.py
@@ -10,7 +10,8 @@ from api.database.models import (
     PlayerHiscoreDataXPChange,
     playerHiscoreData,
 )
-from fastapi import APIRouter, HTTPException, Query
+from api.utils.logging_helpers import build_route_log_string
+from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel
 from sqlalchemy.sql.expression import insert, select
 
@@ -112,6 +113,7 @@ class hiscore(BaseModel):
 @router.get("/v1/hiscore/", tags=["Hiscore"])
 async def get_player_hiscore_data(
     token: str,
+    request: Request,
     player_id: int = Query(..., ge=0),
     row_count: int = Query(100_000, ge=1),
     page: int = Query(1, ge=1),
@@ -120,7 +122,7 @@ async def get_player_hiscore_data(
     Select daily scraped hiscore data, by player_id
     """
     # verify token
-    await verify_token(token, verification="verify_ban", route="[GET]/v1/hiscore")
+    await verify_token(token, verification="verify_ban", route=build_route_log_string(request))
 
     # query
     table = playerHiscoreData
@@ -144,14 +146,14 @@ async def get_player_hiscore_data(
 
 @router.get("/v1/hiscore/Latest", tags=["Hiscore"])
 async def get_latest_hiscore_data_for_an_account(
-    token: str, player_id: int = Query(..., ge=0)
+    token: str, request: Request, player_id: int = Query(..., ge=0)
 ):
     """
     Select the latest hiscore of a player.
     """
     # verify token
     await verify_token(
-        token, verification="verify_ban", route="[GET]/v1/hiscore/Latest"
+        token, verification="verify_ban", route=build_route_log_string(request)
     )
 
     # query
@@ -174,6 +176,7 @@ async def get_latest_hiscore_data_for_an_account(
 @router.get("/v1/hiscore/Latest/bulk", tags=["Hiscore"])
 async def get_latest_hiscore_data_by_player_features(
     token: str,
+    request: Request,
     row_count: int = Query(100_000, ge=1),
     page: int = Query(1, ge=1),
     possible_ban: Optional[int] = Query(None, ge=0, le=1),
@@ -187,7 +190,7 @@ async def get_latest_hiscore_data_by_player_features(
     """
     # verify token
     await verify_token(
-        token, verification="verify_ban", route="[GET]/v1/hiscore/Latest/bulk"
+        token, verification="verify_ban", route=build_route_log_string(request)
     )
 
     if (
@@ -238,6 +241,7 @@ async def get_latest_hiscore_data_by_player_features(
 @router.get("/v1/hiscore/XPChange", tags=["Hiscore"])
 async def get_account_hiscore_xp_change(
     token: str,
+    request: Request,
     player_id: int = Query(..., ge=0),
     row_count: int = Query(100_000, ge=1),
     page: int = Query(1, ge=1),
@@ -247,7 +251,7 @@ async def get_account_hiscore_xp_change(
     """
     # verify token
     await verify_token(
-        token, verification="verify_ban", route="[GET]/v1/hiscore/XPChange"
+        token, verification="verify_ban", route=build_route_log_string(request)
     )
 
     # query
@@ -271,11 +275,11 @@ async def get_account_hiscore_xp_change(
 
 
 @router.post("/v1/hiscore", tags=["Hiscore"])
-async def post_hiscore_data_to_database(hiscores: hiscore, token: str):
+async def post_hiscore_data_to_database(hiscores: hiscore, token: str, request: Request):
     """
     Insert hiscore data.
     """
-    await verify_token(token, verification="verify_ban", route="[POST]/v1/hiscore")
+    await verify_token(token, verification="verify_ban", route=build_route_log_string(request))
 
     values = hiscores.dict()
 

--- a/api/routers/hiscore.py
+++ b/api/routers/hiscore.py
@@ -10,7 +10,7 @@ from api.database.models import (
     PlayerHiscoreDataXPChange,
     playerHiscoreData,
 )
-from api.utils.logging_helpers import build_route_log_string
+from api.utils import logging_helpers
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel
 from sqlalchemy.sql.expression import insert, select
@@ -122,7 +122,11 @@ async def get_player_hiscore_data(
     Select daily scraped hiscore data, by player_id
     """
     # verify token
-    await verify_token(token, verification="verify_ban", route=build_route_log_string(request))
+    await verify_token(
+        token,
+        verification="verify_ban",
+        route=logging_helpers.build_route_log_string(request)
+    )
 
     # query
     table = playerHiscoreData
@@ -153,7 +157,9 @@ async def get_latest_hiscore_data_for_an_account(
     """
     # verify token
     await verify_token(
-        token, verification="verify_ban", route=build_route_log_string(request)
+        token,
+        verification="verify_ban",
+        route=logging_helpers.build_route_log_string(request)
     )
 
     # query
@@ -190,7 +196,9 @@ async def get_latest_hiscore_data_by_player_features(
     """
     # verify token
     await verify_token(
-        token, verification="verify_ban", route=build_route_log_string(request)
+        token,
+        verification="verify_ban",
+        route=logging_helpers.build_route_log_string(request)
     )
 
     if (
@@ -251,7 +259,9 @@ async def get_account_hiscore_xp_change(
     """
     # verify token
     await verify_token(
-        token, verification="verify_ban", route=build_route_log_string(request)
+        token,
+        verification="verify_ban",
+        route=logging_helpers.build_route_log_string(request)
     )
 
     # query
@@ -279,7 +289,11 @@ async def post_hiscore_data_to_database(hiscores: hiscore, token: str, request: 
     """
     Insert hiscore data.
     """
-    await verify_token(token, verification="verify_ban", route=build_route_log_string(request))
+    await verify_token(
+        token,
+        verification="verify_ban",
+        route=logging_helpers.build_route_log_string(request)
+    )
 
     values = hiscores.dict()
 

--- a/api/routers/legacy.py
+++ b/api/routers/legacy.py
@@ -11,7 +11,7 @@ import pandas as pd
 from api import Config
 from api.database.database import (DISCORD_ENGINE, EngineType)
 from api.database.functions import execute_sql, list_to_string, verify_token
-from api.utils.logging_helpers import build_route_log_string
+from api.utils import logging_helpers
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
@@ -834,7 +834,11 @@ async def get_highscores(
     row_count: Optional[int] = 100_000,
     page: Optional[int] = 1,
 ):
-    await verify_token(token, verification="request_highscores", route=build_route_log_string(request, [token]))
+    await verify_token(
+        token,
+        verification="request_highscores",
+        route=logging_helpers.build_route_log_string(request, [token])
+    )
 
     if ofInterest is None:
         sql = """
@@ -865,7 +869,11 @@ async def get_players(
     row_count: int = 100_000,
     page: int = 1
 ):
-    await verify_token(token, verification="request_highscores", route=build_route_log_string(request, [token]))
+    await verify_token(
+        token,
+        verification="request_highscores",
+        route=logging_helpers.build_route_log_string(request, [token])
+    )
 
     # get data
     if ofInterest is None:
@@ -879,7 +887,8 @@ async def get_players(
 
 @router.get("/site/labels/{token}", tags=["Legacy"])
 async def get_labels(token, request: Request):
-    await verify_token(token, verification="request_highscores", route=build_route_log_string(request, [token]))
+    await verify_token(
+        token, verification="request_highscores", route=logging_helpers.build_route_log_string(request, [token]))
 
     sql = "select * from Labels"
     data = await execute_sql(sql)
@@ -888,7 +897,11 @@ async def get_labels(token, request: Request):
 
 @router.post("/site/verify/{token}", tags=["Legacy"])
 async def verify_bot(token: str, bots: bots, request: Request):
-    await verify_token(token, verification="verify_ban", route=build_route_log_string(request, [token]))
+    await verify_token(
+        token,
+        verification="verify_ban",
+        route=logging_helpers.build_route_log_string(request, [token])
+    )
 
     bots = bots.__dict__
     playerNames = bots["names"]
@@ -966,7 +979,11 @@ async def verify_discord_user(
     request: Request,
     version: str = None
 ):
-    await verify_token(token, verification="verify_players", route=build_route_log_string(request, [token]))
+    await verify_token(
+        token,
+        verification="verify_players",
+        route=logging_helpers.build_route_log_string(request, [token])
+    )
 
     verify_data = discord.dict()
 
@@ -1071,7 +1088,11 @@ async def get_prediction(player_name, version=None, token=None):
 ##
 @router.post("/discord/get_xp_gains/{token}", tags=["Legacy"])
 async def get_latest_xp_gains(player_info: PlayerName, token: str, request: Request):
-    await verify_token(token, verification="verify_players", route=build_route_log_string(request, [token]))
+    await verify_token(
+        token,
+        verification="verify_players",
+        route=logging_helpers.build_route_log_string(request, [token])
+    )
 
     player = player_info.dict()
     player_name = player.get("player_name")
@@ -1117,7 +1138,11 @@ async def get_latest_xp_gains(player_info: PlayerName, token: str, request: Requ
     tags=["Legacy"],
 )
 async def get_discord_verification_status_by_name(token: str, player_name: str, request: Request):
-    await verify_token(token, verification="verify_players", route=build_route_log_string(request, [token]))
+    await verify_token(
+        token,
+        verification="verify_players",
+        route=logging_helpers.build_route_log_string(request, [token])
+    )
 
     status_info = await sql_get_discord_verification_status(player_name)
 
@@ -1128,7 +1153,11 @@ async def get_discord_verification_status_by_name(token: str, player_name: str, 
     "/discord/verify/get_verification_attempts/{token}/{player_name}", tags=["Legacy"]
 )
 async def get_discord_verification_attempts(token: str, player_name: str, request: Request,):
-    await verify_token(token, verification="verify_players", route=build_route_log_string(request, [token]))
+    await verify_token(
+        token,
+        verification="verify_players",
+        route=logging_helpers.build_route_log_string(request, [token])
+    )
 
     player = await sql_get_player(player_name)
 
@@ -1148,7 +1177,11 @@ async def post_verification_request_information(
     verify_info: DiscordVerifyInfo,
     request: Request
 ):
-    await verify_token(token, verification="verify_players", route=build_route_log_string(request, [token]))
+    await verify_token(
+        token,
+        verification="verify_players",
+        route=logging_helpers.build_route_log_string(request, [token])
+    )
 
     info = verify_info.dict()
 
@@ -1173,7 +1206,11 @@ async def post_verification_request_information(
 
 @router.get("/discord/get_linked_accounts/{token}/{discord_id}", tags=["Legacy"])
 async def get_discord_linked_accounts(token: str, discord_id: int, request: Request):
-    await verify_token(token, verification="verify_players", route=build_route_log_string(request, [token]))
+    await verify_token(
+        token,
+        verification="verify_players",
+        route=logging_helpers.build_route_log_string(request, [token])
+    )
 
     linked_accounts = await sql_get_discord_linked_accounts(discord_id)
 
@@ -1182,7 +1219,11 @@ async def get_discord_linked_accounts(token: str, discord_id: int, request: Requ
 
 @router.post("/discord/get_latest_sighting/{token}", tags=["Legacy"])
 async def get_latest_sighting(token: str, player_info: PlayerName, request: Request):
-    await verify_token(token, verification="verify_players", route=build_route_log_string(request, [token]))
+    await verify_token(
+        token,
+        verification="verify_players",
+        route=logging_helpers.build_route_log_string(request, [token])
+    )
 
     player = player_info.dict()
     player_name = player.get("player_name")
@@ -1218,7 +1259,11 @@ async def get_latest_sighting(token: str, player_info: PlayerName, request: Requ
 
 @router.post("/discord/region/{token}", tags=["Legacy"])
 async def get_region(token: str, region: RegionName, request: Request):
-    await verify_token(token, verification="verify_players", route=build_route_log_string(request, [token]))
+    await verify_token(
+        token,
+        verification="verify_players",
+        route=logging_helpers.build_route_log_string(request, [token])
+    )
 
     region_info = region.dict()
     region_name = region_info.get("region_name")
@@ -1230,7 +1275,11 @@ async def get_region(token: str, region: RegionName, request: Request):
 
 @router.post("/discord/heatmap/{token}", tags=["Legacy"])
 async def get_heatmap_data(token: str, region_id: RegionID, request: Request):
-    await verify_token(token, verification="verify_players", route=build_route_log_string(request, [token]))
+    await verify_token(
+        token,
+        verification="verify_players",
+        route=logging_helpers.build_route_log_string(request, [token])
+    )
 
     region_data = region_id.dict()
     id = region_data.get("region_id")
@@ -1253,7 +1302,11 @@ async def get_heatmap_data(token: str, region_id: RegionID, request: Request):
 
 @router.post("/discord/player_bans/{token}", tags=["Legacy"])
 async def generate_excel_export(token: str, export_info: ExportInfo, request: Request):
-    await verify_token(token, verification="verify_players", route=build_route_log_string(request, [token]))
+    await verify_token(
+        token,
+        verification="verify_players",
+        route=logging_helpers.build_route_log_string(request, [token])
+    )
 
     # get_ban_spreadsheet_data
     req_data = export_info.dict()

--- a/api/routers/legacy.py
+++ b/api/routers/legacy.py
@@ -9,9 +9,10 @@ from typing import List, Optional
 
 import pandas as pd
 from api import Config
-from api.database.database import (DISCORD_ENGINE, PLAYERDATA_ENGINE, EngineType)
+from api.database.database import (DISCORD_ENGINE, EngineType)
 from api.database.functions import execute_sql, list_to_string, verify_token
-from fastapi import APIRouter, HTTPException
+from api.utils.logging_helpers import build_route_log_string
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 from sqlalchemy.orm.exc import NoResultFound
@@ -828,11 +829,12 @@ async def receive_plugin_feedback(feedback: Feedback, version: str = None):
 @router.get("/site/highscores/{token}/{ofInterest}/{row_count}/{page}", tags=["Legacy"])
 async def get_highscores(
     token: str,
+    request: Request,
     ofInterest: int = None,
     row_count: Optional[int] = 100_000,
     page: Optional[int] = 1,
 ):
-    await verify_token(token, verification="request_highscores", route="[GET]/site/highscores/")
+    await verify_token(token, verification="request_highscores", route=build_route_log_string(request, [token]))
 
     if ofInterest is None:
         sql = """
@@ -857,9 +859,13 @@ async def get_highscores(
 
 @router.get("site/players/{token}/{ofInterest}/{row_count}/{page}", tags=["Legacy"])
 async def get_players(
-    token: str, ofInterest: int = None, row_count: int = 100_000, page: int = 1
+    token: str,
+    request: Request,
+    ofInterest: int = None,
+    row_count: int = 100_000,
+    page: int = 1
 ):
-    await verify_token(token, verification="request_highscores", route="[GET]/site/players/")
+    await verify_token(token, verification="request_highscores", route=build_route_log_string(request, [token]))
 
     # get data
     if ofInterest is None:
@@ -871,9 +877,9 @@ async def get_players(
     return data.rows2dict() if data is not None else {}
 
 
-@router.get("/site/labels/{tokens}", tags=["Legacy"])
-async def get_labels(token):
-    await verify_token(token, verification="request_highscores", route="[GET]/site/labels/")
+@router.get("/site/labels/{token}", tags=["Legacy"])
+async def get_labels(token, request: Request):
+    await verify_token(token, verification="request_highscores", route=build_route_log_string(request, [token]))
 
     sql = "select * from Labels"
     data = await execute_sql(sql)
@@ -881,8 +887,8 @@ async def get_labels(token):
 
 
 @router.post("/site/verify/{token}", tags=["Legacy"])
-async def verify_bot(token: str, bots: bots):
-    await verify_token(token, verification="verify_ban",route="[POST]/site/verify/")
+async def verify_bot(token: str, bots: bots, request: Request):
+    await verify_token(token, verification="verify_ban", route=build_route_log_string(request, [token]))
 
     bots = bots.__dict__
     playerNames = bots["names"]
@@ -954,8 +960,13 @@ async def set_discord_verification(id, token):
 
 
 @router.post("/{version}/site/discord_user/{token}", tags=["Legacy"])
-async def verify_discord_user(token: str, discord: discord, version: str = None):
-    await verify_token(token, verification="verify_players", route=f"[POST]/{version}/site/discord_user/")
+async def verify_discord_user(
+    token: str,
+    discord: discord,
+    request: Request,
+    version: str = None
+):
+    await verify_token(token, verification="verify_players", route=build_route_log_string(request, [token]))
 
     verify_data = discord.dict()
 
@@ -1059,8 +1070,8 @@ async def get_prediction(player_name, version=None, token=None):
 #  Discord
 ##
 @router.post("/discord/get_xp_gains/{token}", tags=["Legacy"])
-async def get_latest_xp_gains(player_info: PlayerName, token: str):
-    await verify_token(token, verification="verify_players", route="[POST]/discord/get_xp_gains/")
+async def get_latest_xp_gains(player_info: PlayerName, token: str, request: Request):
+    await verify_token(token, verification="verify_players", route=build_route_log_string(request, [token]))
 
     player = player_info.dict()
     player_name = player.get("player_name")
@@ -1105,8 +1116,8 @@ async def get_latest_xp_gains(player_info: PlayerName, token: str):
     "/discord/verify/player_rsn_discord_account_status/{token}/{player_name}",
     tags=["Legacy"],
 )
-async def get_discord_verification_status_by_name(token: str, player_name: str):
-    await verify_token(token, verification="verify_players", route=f"[GET]/discord/verify/player_rsn_discord_account_status/***/{player_name}")
+async def get_discord_verification_status_by_name(token: str, player_name: str, request: Request):
+    await verify_token(token, verification="verify_players", route=build_route_log_string(request, [token]))
 
     status_info = await sql_get_discord_verification_status(player_name)
 
@@ -1116,8 +1127,8 @@ async def get_discord_verification_status_by_name(token: str, player_name: str):
 @router.get(
     "/discord/verify/get_verification_attempts/{token}/{player_name}", tags=["Legacy"]
 )
-async def get_discord_verification_attempts(token: str, player_name: str):
-    await verify_token(token, verification="verify_players", route=f"[GET]/discord/verify/get_verification_attempts/***/{player_name}")
+async def get_discord_verification_attempts(token: str, player_name: str, request: Request,):
+    await verify_token(token, verification="verify_players", route=build_route_log_string(request, [token]))
 
     player = await sql_get_player(player_name)
 
@@ -1133,9 +1144,11 @@ async def get_discord_verification_attempts(token: str, player_name: str):
 
 @router.post("/discord/verify/insert_player_dpc/{token}", tags=["Legacy"])
 async def post_verification_request_information(
-    token: str, verify_info: DiscordVerifyInfo
+    token: str,
+    verify_info: DiscordVerifyInfo,
+    request: Request
 ):
-    await verify_token(token, verification="verify_players", route="[POST]/discord/verify/insert_player_dpc/***")
+    await verify_token(token, verification="verify_players", route=build_route_log_string(request, [token]))
 
     info = verify_info.dict()
 
@@ -1159,8 +1172,8 @@ async def post_verification_request_information(
 
 
 @router.get("/discord/get_linked_accounts/{token}/{discord_id}", tags=["Legacy"])
-async def get_discord_linked_accounts(token: str, discord_id: int):
-    await verify_token(token, verification="verify_players", route=f"[GET]/discord/get_linked_accounts/***/{discord_id}")
+async def get_discord_linked_accounts(token: str, discord_id: int, request: Request):
+    await verify_token(token, verification="verify_players", route=build_route_log_string(request, [token]))
 
     linked_accounts = await sql_get_discord_linked_accounts(discord_id)
 
@@ -1168,8 +1181,8 @@ async def get_discord_linked_accounts(token: str, discord_id: int):
 
 
 @router.post("/discord/get_latest_sighting/{token}", tags=["Legacy"])
-async def get_latest_sighting(token: str, player_info: PlayerName):
-    await verify_token(token, verification="verify_players", route=f"[POST]/discord/get_latest_sighting/***")
+async def get_latest_sighting(token: str, player_info: PlayerName, request: Request):
+    await verify_token(token, verification="verify_players", route=build_route_log_string(request, [token]))
 
     player = player_info.dict()
     player_name = player.get("player_name")
@@ -1204,8 +1217,8 @@ async def get_latest_sighting(token: str, player_info: PlayerName):
 
 
 @router.post("/discord/region/{token}", tags=["Legacy"])
-async def get_region(token: str, region: RegionName):
-    await verify_token(token, verification="verify_players", route=f"[POST]/discord/region/***")
+async def get_region(token: str, region: RegionName, request: Request):
+    await verify_token(token, verification="verify_players", route=build_route_log_string(request, [token]))
 
     region_info = region.dict()
     region_name = region_info.get("region_name")
@@ -1216,8 +1229,8 @@ async def get_region(token: str, region: RegionName):
 
 
 @router.post("/discord/heatmap/{token}", tags=["Legacy"])
-async def get_heatmap_data(token: str, region_id: RegionID):
-    await verify_token(token, verification="verify_players", route=f"[POST]/discord/heatmap/***")
+async def get_heatmap_data(token: str, region_id: RegionID, request: Request):
+    await verify_token(token, verification="verify_players", route=build_route_log_string(request, [token]))
 
     region_data = region_id.dict()
     id = region_data.get("region_id")
@@ -1239,10 +1252,10 @@ async def get_heatmap_data(token: str, region_id: RegionID):
 
 
 @router.post("/discord/player_bans/{token}", tags=["Legacy"])
-async def generate_excel_export(token: str, export_info: ExportInfo):
-    await verify_token(token, verification="verify_players", route=f"[POST]/discord/player_bans/***")
-    # get_ban_spreadsheet_data
+async def generate_excel_export(token: str, export_info: ExportInfo, request: Request):
+    await verify_token(token, verification="verify_players", route=build_route_log_string(request, [token]))
 
+    # get_ban_spreadsheet_data
     req_data = export_info.dict()
     discord_id = req_data.get("discord_id")
     display_name = req_data.get("display_name")

--- a/api/routers/player.py
+++ b/api/routers/player.py
@@ -6,7 +6,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.database.database import Engine, EngineType
 from api.database.functions import sqlalchemy_result, verify_token
 from api.database.models import Player as dbPlayer
-from fastapi import APIRouter, HTTPException, Query
+from api.utils.logging_helpers import build_route_log_string
+from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel
 from sqlalchemy.sql.expression import insert, select, update
 
@@ -26,6 +27,7 @@ class Player(BaseModel):
 @router.get("/v1/player", tags=["Player"])
 async def get_player_information(
     token: str,
+    request: Request,
     player_name: Optional[str] = None,
     player_id: Optional[int] = Query(None, ge=0),
     row_count: int = Query(100_000, ge=1),
@@ -35,7 +37,7 @@ async def get_player_information(
     Select a player by name or id.
     """
     await verify_token(
-        token, verification="request_highscores", route="[GET]/v1/player"
+        token, verification="request_highscores", route=build_route_log_string(request)
     )
 
     # return exception if no param are given
@@ -67,6 +69,7 @@ async def get_player_information(
 @router.get("/v1/player/bulk", tags=["Player"])
 async def get_bulk_player_data_from_the_plugin_database(
     token: str,
+    request: Request,
     possible_ban: Optional[int] = None,
     confirmed_ban: Optional[int] = None,
     confirmed_player: Optional[int] = None,
@@ -79,7 +82,7 @@ async def get_bulk_player_data_from_the_plugin_database(
     Selects bulk player data from the plugin database.
     """
     await verify_token(
-        token, verification="request_highscores", route="[POST]/v1/player"
+        token, verification="request_highscores", route=build_route_log_string(request)
     )
 
     # return exception if no param are given
@@ -127,11 +130,11 @@ async def get_bulk_player_data_from_the_plugin_database(
 
 
 @router.put("/v1/player", tags=["Player"])
-async def update_existing_player_data(player: Player, token: str):
+async def update_existing_player_data(player: Player, token: str, request: Request):
     """
     Update player & return updated player.
     """
-    await verify_token(token, verification="verify_ban")
+    await verify_token(token, verification="verify_ban", route=build_route_log_string(request))
 
     # param
     param = player.dict()
@@ -160,11 +163,11 @@ async def update_existing_player_data(player: Player, token: str):
 
 
 @router.post("/v1/player", tags=["Player"])
-async def insert_new_player_data_into_plugin_database(player_name: str, token: str):
+async def insert_new_player_data_into_plugin_database(player_name: str, token: str, request: Request):
     """
     Insert new player & return player.
     """
-    await verify_token(token, verification="verify_ban", route="[POST]/v1/player")
+    await verify_token(token, verification="verify_ban", route=build_route_log_string(request))
 
     sql_insert = insert(dbPlayer)
     sql_insert = sql_insert.values(name=player_name)

--- a/api/routers/player.py
+++ b/api/routers/player.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.database.database import Engine, EngineType
 from api.database.functions import sqlalchemy_result, verify_token
 from api.database.models import Player as dbPlayer
-from api.utils.logging_helpers import build_route_log_string
+from api.utils import logging_helpers
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel
 from sqlalchemy.sql.expression import insert, select, update
@@ -37,7 +37,9 @@ async def get_player_information(
     Select a player by name or id.
     """
     await verify_token(
-        token, verification="request_highscores", route=build_route_log_string(request)
+        token,
+        verification="request_highscores",
+        route=logging_helpers.build_route_log_string(request)
     )
 
     # return exception if no param are given
@@ -82,7 +84,9 @@ async def get_bulk_player_data_from_the_plugin_database(
     Selects bulk player data from the plugin database.
     """
     await verify_token(
-        token, verification="request_highscores", route=build_route_log_string(request)
+        token,
+        verification="request_highscores",
+        route=logging_helpers.build_route_log_string(request)
     )
 
     # return exception if no param are given
@@ -134,7 +138,11 @@ async def update_existing_player_data(player: Player, token: str, request: Reque
     """
     Update player & return updated player.
     """
-    await verify_token(token, verification="verify_ban", route=build_route_log_string(request))
+    await verify_token(
+        token,
+        verification="verify_ban",
+        route=logging_helpers.build_route_log_string(request)
+    )
 
     # param
     param = player.dict()
@@ -167,7 +175,11 @@ async def insert_new_player_data_into_plugin_database(player_name: str, token: s
     """
     Insert new player & return player.
     """
-    await verify_token(token, verification="verify_ban", route=build_route_log_string(request))
+    await verify_token(
+        token,
+        verification="verify_ban",
+        route=logging_helpers.build_route_log_string(request)
+    )
 
     sql_insert = insert(dbPlayer)
     sql_insert = sql_insert.values(name=player_name)

--- a/api/routers/prediction.py
+++ b/api/routers/prediction.py
@@ -9,7 +9,7 @@ from api.database.functions import (
 )
 from api.database.models import Player, PlayerHiscoreDataLatest
 from api.database.models import Prediction as dbPrediction
-from api.utils.logging_helpers import build_route_log_string
+from api.utils import logging_helpers
 from fastapi import APIRouter, HTTPException, Query, status, Request
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -113,7 +113,11 @@ async def insert_prediction_into_plugin_database(
     Posts a new prediction into the plugin database.\n
     Use: Can be used to insert a new prediction into the plugin database.
     """
-    await verify_token(token, verification="verify_ban", route=build_route_log_string(request))
+    await verify_token(
+        token,
+        verification="verify_ban",
+        route=logging_helpers.build_route_log_string(request)
+    )
 
     data = [d.dict() for d in prediction]
 
@@ -186,7 +190,9 @@ async def gets_predictions_by_player_features(
     Get predictions by player features
     """
     await verify_token(
-        token, verification="request_highscores", route=build_route_log_string(request)
+        token,
+        verification="request_highscores",
+        route=logging_helpers.build_route_log_string(request)
     )
 
     if (

--- a/api/routers/prediction.py
+++ b/api/routers/prediction.py
@@ -9,7 +9,8 @@ from api.database.functions import (
 )
 from api.database.models import Player, PlayerHiscoreDataLatest
 from api.database.models import Prediction as dbPrediction
-from fastapi import APIRouter, HTTPException, Query, status
+from api.utils.logging_helpers import build_route_log_string
+from fastapi import APIRouter, HTTPException, Query, status, Request
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.expression import Select, select, text
@@ -104,13 +105,15 @@ async def get_account_prediction_result(name: str, breakdown: Optional[bool] = F
 
 @router.post("/v1/prediction", tags=["Prediction"])
 async def insert_prediction_into_plugin_database(
-    token: str, prediction: List[Prediction]
+    token: str,
+    prediction: List[Prediction], 
+    request: Request
 ):
     """
     Posts a new prediction into the plugin database.\n
     Use: Can be used to insert a new prediction into the plugin database.
     """
-    await verify_token(token, verification="verify_ban", route="[POST]/v1/prediction/")
+    await verify_token(token, verification="verify_ban", route=build_route_log_string(request))
 
     data = [d.dict() for d in prediction]
 
@@ -170,6 +173,7 @@ async def get_expired_predictions(token: str, limit: int = Query(50_000, ge=1)):
 @router.get("/v1/prediction/bulk", tags=["Prediction"])
 async def gets_predictions_by_player_features(
     token: str,
+    request: Request,
     row_count: int = Query(100_000, ge=1),
     page: int = Query(1, ge=1),
     possible_ban: Optional[int] = Query(None, ge=0, le=1),
@@ -182,7 +186,7 @@ async def gets_predictions_by_player_features(
     Get predictions by player features
     """
     await verify_token(
-        token, verification="request_highscores", route="[GET]/v1/prediction/bulk"
+        token, verification="request_highscores", route=build_route_log_string(request)
     )
 
     if (

--- a/api/routers/report.py
+++ b/api/routers/report.py
@@ -9,7 +9,8 @@ from api.database import functions
 from api.database.functions import PLAYERDATA_ENGINE
 from api.database.models import (Player, Prediction, Report,
                                  playerReports, playerReportsManual, stgReport)
-from fastapi import APIRouter, HTTPException, Query, status
+from api.utils.logging_helpers import build_route_log_string
+from fastapi import APIRouter, HTTPException, Query, status, Request
 from pydantic import BaseModel
 from pydantic.fields import Field
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -123,6 +124,7 @@ class detection(BaseModel):
 @router.get("/v1/report", tags=["Report"])
 async def get_reports(
     token: str,
+    request: Request,
     reportedID: Optional[int] = Query(None, ge=0),
     reportingID: Optional[int] = Query(None, ge=0),
     timestamp: Optional[date] = None,
@@ -132,7 +134,7 @@ async def get_reports(
     Select report data.
     """
     await functions.verify_token(
-        token, verification="verify_ban", route="[GET]/v1/report/"
+        token, verification="verify_ban", route=build_route_log_string(request)
     )
 
     if None == reportedID == reportingID:
@@ -165,12 +167,12 @@ async def get_reports(
 
 
 @router.put("/v1/report", tags=["Report"])
-async def update_reports(old_user_id: int, new_user_id: int, token: str):
+async def update_reports(old_user_id: int, new_user_id: int, token: str, request: Request):
     """
     Update the reports from one reporting user to another.
     """
     await functions.verify_token(
-        token, verification="verify_ban", route="[PUT]/v1/report/"
+        token, verification="verify_ban", route=build_route_log_string(request)
     )
     # can be used for name change
 

--- a/api/routers/report.py
+++ b/api/routers/report.py
@@ -9,7 +9,7 @@ from api.database import functions
 from api.database.functions import PLAYERDATA_ENGINE
 from api.database.models import (Player, Prediction, Report,
                                  playerReports, playerReportsManual, stgReport)
-from api.utils.logging_helpers import build_route_log_string
+from api.utils import logging_helpers
 from fastapi import APIRouter, HTTPException, Query, status, Request
 from pydantic import BaseModel
 from pydantic.fields import Field
@@ -134,7 +134,9 @@ async def get_reports(
     Select report data.
     """
     await functions.verify_token(
-        token, verification="verify_ban", route=build_route_log_string(request)
+        token,
+        verification="verify_ban",
+        route=logging_helpers.build_route_log_string(request)
     )
 
     if None == reportedID == reportingID:
@@ -172,7 +174,9 @@ async def update_reports(old_user_id: int, new_user_id: int, token: str, request
     Update the reports from one reporting user to another.
     """
     await functions.verify_token(
-        token, verification="verify_ban", route=build_route_log_string(request)
+        token,
+        verification="verify_ban",
+        route=logging_helpers.build_route_log_string(request)
     )
     # can be used for name change
 

--- a/api/routers/scraper.py
+++ b/api/routers/scraper.py
@@ -10,7 +10,7 @@ from api.database.database import EngineType
 from api.database.functions import batch_function, execute_sql, verify_token
 from api.database.models import Player as dbPlayer
 from api.database.models import playerHiscoreData
-from api.utils.logging_helpers import build_route_log_string
+from api.utils import logging_helpers
 from fastapi import APIRouter, BackgroundTasks, Request
 from pydantic import BaseModel
 from sqlalchemy.exc import InternalError, OperationalError
@@ -187,7 +187,9 @@ async def sqla_insert_hiscore(hiscores: List):
 @router.post("/scraper/hiscores/{token}", tags=["Business"])
 async def receive_scraper_data(token, data: List[scraper], request: Request):
     await verify_token(
-        token, verification="verify_ban", route=build_route_log_string(request)
+        token,
+        verification="verify_ban",
+        route=logging_helpers.build_route_log_string(request)
     )
     # background task will cause lots of duplicates
     asyncio.create_task(post_hiscores_to_db(data))

--- a/api/routers/scraper.py
+++ b/api/routers/scraper.py
@@ -10,7 +10,8 @@ from api.database.database import EngineType
 from api.database.functions import batch_function, execute_sql, verify_token
 from api.database.models import Player as dbPlayer
 from api.database.models import playerHiscoreData
-from fastapi import APIRouter, BackgroundTasks
+from api.utils.logging_helpers import build_route_log_string
+from fastapi import APIRouter, BackgroundTasks, Request
 from pydantic import BaseModel
 from sqlalchemy.exc import InternalError, OperationalError
 from sqlalchemy.sql.expression import insert, update
@@ -184,9 +185,9 @@ async def sqla_insert_hiscore(hiscores: List):
 
 
 @router.post("/scraper/hiscores/{token}", tags=["Business"])
-async def receive_scraper_data(token, data: List[scraper]):
+async def receive_scraper_data(token, data: List[scraper], request: Request):
     await verify_token(
-        token, verification="verify_ban", route="[POST]/scraper/hiscores/token"
+        token, verification="verify_ban", route=build_route_log_string(request)
     )
     # background task will cause lots of duplicates
     asyncio.create_task(post_hiscores_to_db(data))

--- a/api/utils/logging_helpers.py
+++ b/api/utils/logging_helpers.py
@@ -1,4 +1,16 @@
 from fastapi import Request
+from typing import List
+from functools import reduce
 
-def build_route_log_string(request: Request) -> str:
-  return f"[{request.method}] Path: {request.url.path} Query Params: {request.query_params}"
+
+def build_route_log_string(request: Request, censored_strings: List[str]) -> str:
+  log_str = f"[{request.method}] Path: {request.url.path} Query Params: {request.query_params}"
+
+  return log_str if not censored_strings else censor_log_entry(log_str, censored_strings)
+
+
+def censor_log_entry(log_str: str, censored_strings: List[str]) -> str:
+
+  [log_str := log_str.replace(censored, "***") for censored in censored_strings]
+
+  return log_str

--- a/api/utils/logging_helpers.py
+++ b/api/utils/logging_helpers.py
@@ -3,31 +3,31 @@ from typing import List
 
 
 def build_route_log_string(request: Request, censored_strings: List[str] = []) -> str:
-  """
-  Creates a string for logging purposes that contains information about how a route was accessed.
+    """
+    Creates a string for logging purposes that contains information about how a route was accessed.
 
-  Parameters
-  ----------
-  request : Request
-    A Starlette Request object containing information about the HTTP request received.
-  
-  censored_strings : List[str] (Optional)
-    A list of substrings that will be replaced with '***' in the log string.
+    Parameters
+    ----------
+    request : Request
+      A Starlette Request object containing information about the HTTP request received.
+    
+    censored_strings : List[str] (Optional)
+      A list of substrings that will be replaced with '***' in the log string.
 
-  Returns
-  ----------
-    A string containing information about the request.
+    Returns
+    ----------
+      A string containing information about the request.
 
-  Example:
-    "[POST] Path: /1.3.2/site/discord_user/*** Query Params: test=true"
-  """
-  log_str = f"[{request.method}] Path: {request.url.path} Query Params: {request.query_params}"
+    Example:
+      "[POST] Path: /1.3.2/site/discord_user/*** Query Params: test=true"
+    """
+    log_str = f"[{request.method}] Path: {request.url.path} Query Params: {request.query_params}"
 
-  return log_str if not censored_strings else censor_log_entry(log_str, censored_strings)
+    return log_str if not censored_strings else censor_log_entry(log_str, censored_strings)
 
 
 def censor_log_entry(log_str: str, censored_strings: List[str]) -> str:
 
-  [log_str := log_str.replace(censored, "***") for censored in censored_strings]
+    [log_str := log_str.replace(censored, "***") for censored in censored_strings]
 
-  return log_str
+    return log_str

--- a/api/utils/logging_helpers.py
+++ b/api/utils/logging_helpers.py
@@ -1,0 +1,4 @@
+from fastapi import Request
+
+def build_route_log_string(request: Request) -> str:
+  return f"[{request.method}] Path: {request.url.path} Query Params: {request.query_params}"

--- a/api/utils/logging_helpers.py
+++ b/api/utils/logging_helpers.py
@@ -9,17 +9,17 @@ def build_route_log_string(request: Request, censored_strings: List[str] = []) -
     Parameters
     ----------
     request : Request
-      A Starlette Request object containing information about the HTTP request received.
-    
+        A Starlette Request object containing information about the HTTP request received.
+
     censored_strings : List[str] (Optional)
-      A list of substrings that will be replaced with '***' in the log string.
+        A list of substrings that will be replaced with '***' in the log string.
 
     Returns
     ----------
-      A string containing information about the request.
+        A string containing information about the request.
 
     Example:
-      "[POST] Path: /1.3.2/site/discord_user/*** Query Params: test=true"
+        "[POST] Path: /1.3.2/site/discord_user/*** Query Params: test=true"
     """
     log_str = f"[{request.method}] Path: {request.url.path} Query Params: {request.query_params}"
 
@@ -27,6 +27,30 @@ def build_route_log_string(request: Request, censored_strings: List[str] = []) -
 
 
 def censor_log_entry(log_str: str, censored_strings: List[str]) -> str:
+    """
+    Replaces instances of the substrings contained within
+        censored__strings located within log_str with '***'
+
+    Parameters
+    ----------
+    log_str : str
+        The string to be logged prior to censorship.
+
+    censored_strings : List[str] (Optional)
+        A list of substrings that will be replaced with '***' in the log string.
+
+    Returns
+    ----------
+        A log string with any censored substrings replaced with ***.
+
+    Example:
+        Params:
+            log_str: "[GET] /some/route/1234abcd/players"
+            censored_strings: ["1234abcd"]
+
+        Returns:
+            "[GET] /some/route/***/players"
+    """
 
     [log_str := log_str.replace(censored, "***") for censored in censored_strings]
 

--- a/api/utils/logging_helpers.py
+++ b/api/utils/logging_helpers.py
@@ -24,8 +24,6 @@ def build_route_log_string(request: Request, censored_strings: List[str] = []) -
   """
   log_str = f"[{request.method}] Path: {request.url.path} Query Params: {request.query_params}"
 
-  print(log_str)
-
   return log_str if not censored_strings else censor_log_entry(log_str, censored_strings)
 
 

--- a/api/utils/logging_helpers.py
+++ b/api/utils/logging_helpers.py
@@ -3,8 +3,28 @@ from typing import List
 from functools import reduce
 
 
-def build_route_log_string(request: Request, censored_strings: List[str]) -> str:
+def build_route_log_string(request: Request, censored_strings: List[str] = []) -> str:
+  """
+  Creates a string for logging purposes that contains information about how a route was accessed.
+
+  Parameters
+  ----------
+  request : Request
+    A Starlette Request object containing information about the HTTP request received.
+  
+  censored_strings : List[str] (Optional)
+    A list of substrings that will be replaced with '***' in the log string.
+
+  Returns
+  ----------
+    A string containing information about the request.
+
+  Example:
+    "[POST] Path: /1.3.2/site/discord_user/*** Query Params: test=true"
+  """
   log_str = f"[{request.method}] Path: {request.url.path} Query Params: {request.query_params}"
+
+  print(log_str)
 
   return log_str if not censored_strings else censor_log_entry(log_str, censored_strings)
 

--- a/api/utils/logging_helpers.py
+++ b/api/utils/logging_helpers.py
@@ -1,6 +1,5 @@
 from fastapi import Request
 from typing import List
-from functools import reduce
 
 
 def build_route_log_string(request: Request, censored_strings: List[str] = []) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+# Fixtures defined in this file can be passed as parameters to tests without the need to import
+# this file. See the following link for more information:
+# https://www.tutorialspoint.com/pytest/pytest_conftest_py.htm
+
 import os
 import sys
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.app import app
+
+@pytest.fixture
+def test_client():
+    """Returns a Starlette test API instance"""
+    return TestClient(app)

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -4,12 +4,8 @@ import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import pytest
-from api import app
-from fastapi.testclient import TestClient
 
-client = TestClient(app.app)
-
-def test_get_feedback():
+def test_get_feedback(test_client):
     url = "/v1/feedback/count/"
     test_cases = [
         {"name":"3BA604236FB0319D5937E31388B0C64C", "status_code": 200}
@@ -17,7 +13,7 @@ def test_get_feedback():
     for case in test_cases:
         param = {"name": case.get("name")}
 
-        response = client.get(url, params=param)
+        response = test_client.get(url, params=param)
 
         print(response.url)
         print(response.text)

--- a/tests/test_hiscore.py
+++ b/tests/test_hiscore.py
@@ -3,14 +3,9 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from api import app
 from api.Config import token
-from fastapi.testclient import TestClient
 
-client = TestClient(app.app)
-
-
-def test_get_player_hiscore_data():
+def test_get_player_hiscore_data(test_client):
     test_cases = [
         {"player_id": 1, "status_code": 200, "detail": "valid player"},
         {"player_id": -1, "status_code": 422, "detail": "invalid player id"},
@@ -22,7 +17,7 @@ def test_get_player_hiscore_data():
         url = "/v1/hiscore/"
         param = {"player_id": case.get("player_id"), "token": token}
 
-        response = client.get(url, params=param)
+        response = test_client.get(url, params=param)
 
         print(response.url)
         print(response.text)
@@ -38,7 +33,7 @@ def test_get_player_hiscore_data():
             assert isinstance(response.json(), list), error
 
 
-def test_get_latest_hiscore_data_for_an_account():
+def test_get_latest_hiscore_data_for_an_account(test_client):
     test_cases = [
         {"player_id": 1, "status_code": 200, "detail": "valid player"},
         {"player_id": -1, "status_code": 422, "detail": "invalid player id"},
@@ -50,7 +45,7 @@ def test_get_latest_hiscore_data_for_an_account():
         url = "/v1/hiscore/Latest/"
         param = {"player_id": case.get("player_id"), "token": token}
 
-        response = client.get(url, params=param)
+        response = test_client.get(url, params=param)
 
         print(response.url)
         print(response.text)
@@ -67,7 +62,7 @@ def test_get_latest_hiscore_data_for_an_account():
 
 
 # TODO: cleanup
-def test_get_latest_hiscore_data_by_player_features():
+def test_get_latest_hiscore_data_by_player_features(test_client):
     test_case = (
         (1, 1, 0, 0, 2, 200),  # banned account
         (0, 0, 0, 0, 0, 200),  # normal player
@@ -84,7 +79,7 @@ def test_get_latest_hiscore_data_by_player_features():
         response_code,
     ) in enumerate(test_case):
         route_attempt = f"/v1/hiscore/Latest/bulk?token={token}&row_count=10&page=1&possible_ban={possible_ban}&confirmed_ban={confirmed_ban}&confirmed_player={confirmed_player}&label_id={label_id}&label_jagex={label_jagex}"
-        response = client.get(route_attempt)
+        response = test_client.get(route_attempt)
         assert (
             response.status_code == response_code
         ), f"Test: {test}| Invalid response {response.status_code}"
@@ -94,7 +89,7 @@ def test_get_latest_hiscore_data_by_player_features():
             ), f"invalid response return type: {type(response.json())}"
 
 
-def test_get_account_hiscore_xp_change():
+def test_get_account_hiscore_xp_change(test_client):
     test_cases = [
         {"player_id": 1, "status_code": 200, "detail": "valid player"},
         {"player_id": -1, "status_code": 422, "detail": "invalid player id"},
@@ -106,7 +101,7 @@ def test_get_account_hiscore_xp_change():
         url = "/v1/hiscore/XPChange"
         param = {"player_id": case.get("player_id"), "token": token}
 
-        response = client.get(url, params=param)
+        response = test_client.get(url, params=param)
 
         print(response.url)
         print(response.text)

--- a/tests/test_label.py
+++ b/tests/test_label.py
@@ -4,14 +4,9 @@ import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import pytest
-from api import app
 from api.Config import token
-from fastapi.testclient import TestClient
 
-client = TestClient(app.app)
-
-
-def test_get_labels():
+def test_get_labels(test_client):
     url = "/v1/label/"
     test_cases = [
         {"token": token, "status_code": 200},
@@ -21,7 +16,7 @@ def test_get_labels():
     for case in test_cases:
         param = {"token": case.get("token")}
 
-        response = client.get(url, params=param)
+        response = test_client.get(url, params=param)
 
         print(response.url)
         print(response.text)

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -3,15 +3,9 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-
-from api import app
 from api.Config import token
-from fastapi.testclient import TestClient
 
-client = TestClient(app.app)
-
-
-def test_get_player_information():
+def test_get_player_information(test_client):
     test_cases = [
         {"player_id": 1, "status_code": 200, "detail": "valid player"},
         {"player_id": -1, "status_code": 422, "detail": "invalid player id"},
@@ -23,7 +17,7 @@ def test_get_player_information():
         url = "/v1/player/"
         param = {"player_id": case.get("player_id"), "token": token}
 
-        response = client.get(url, params=param)
+        response = test_client.get(url, params=param)
 
         print(response.url)
         print(response.text)

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -4,12 +4,7 @@ from typing import Union
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from api import app
-from fastapi.testclient import TestClient
 from pydantic import BaseModel
-
-client = TestClient(app.app)
-
 class Prediction(BaseModel):
     player_id: int
     player_name: str
@@ -30,7 +25,7 @@ def parse_response(response):
     except Exception as e:
         assert False, e
     
-def test_prediction():
+def test_prediction(test_client):
     url = "/v1/prediction/"
     breakdown_param = [
         {
@@ -46,7 +41,7 @@ def test_prediction():
         }
     ]
     for param in breakdown_param:
-        response = client.get(url, params=param)
+        response = test_client.get(url, params=param)
         check_response(response, param, 200)
         prediction = parse_response(response)
         error = f"Expected prediction_confidence is not None, {param=}"
@@ -64,7 +59,7 @@ def test_prediction():
         }
     ]
     for param in no_breakdown_param:
-        response = client.get(url, params=param)
+        response = test_client.get(url, params=param)
         check_response(response, param, 200)
         prediction = parse_response(response)
         error = f"Expected prediction_confidence is None, {param=}"
@@ -76,7 +71,7 @@ def test_prediction():
         "name": "2C09003E9EA22E5F245023B5555C0AD9",
         "breakdown": True
     }
-    response = client.get(url, params=param)
+    response = test_client.get(url, params=param)
     check_response(response, param, 200)
     prediction = parse_response(response)
     error = f"Expected prediction_confidence is None, {param=}"
@@ -87,5 +82,5 @@ def test_prediction():
     param = {
         "name": None
     }
-    response = client.get(url, params=param)
+    response = test_client.get(url, params=param)
     check_response(response, param, 422)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -2,16 +2,11 @@ import os
 import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-import time
 
 import pytest
-from api import app
 from api.Config import token
-from fastapi.testclient import TestClient
 
-client = TestClient(app.app)
-
-def test_report_count():
+def test_report_count(test_client):
     url = "/v1/report/count"
     test_cases = [
         {"name": "3BA604236FB0319D5937E31388B0C64C", "status_code": 200},
@@ -20,7 +15,7 @@ def test_report_count():
     for case in test_cases:
         param = {"token": token, "name": case.get("name")}
 
-        response = client.get(url, params=param)
+        response = test_client.get(url, params=param)
 
         print(response.url)
         print(response.text)

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -2,17 +2,12 @@ import os
 import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-import time
 
-from api import app
 from api.Config import token
-from fastapi.testclient import TestClient
 
-client = TestClient(app.app)
-
-def test_scraper_players():
+def test_scraper_players(test_client):
     url = f"/scraper/players/0/10/{token}"
-    response = client.get(url)
+    response = test_client.get(url)
 
     print(response.url)
     print(response.text)

--- a/tests/utils/test_logging_helpers.py
+++ b/tests/utils/test_logging_helpers.py
@@ -1,0 +1,28 @@
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from api.Config import token
+from api.database.functions import verify_token
+from api.routers import legacy
+
+
+request_path = f"/discord/get_linked_accounts/{token}/1"
+
+
+def test_build_route_log_string(test_client):
+    """
+    Tests if verify_token within legacy.get_discord_linked_accounts
+    gets called with the proper log string passed into it.
+    """
+
+    with patch.object(legacy, 'verify_token', return_value=None) as mock:
+        test_client.get(request_path)
+
+        mock.assert_called_once_with(token, "verify_players", request_path.replace(token, "***"))
+
+
+def censor_log_entry():
+    ...

--- a/tests/utils/test_logging_helpers.py
+++ b/tests/utils/test_logging_helpers.py
@@ -5,10 +5,12 @@ from unittest.mock import patch
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from api.Config import token
-from api.routers import legacy
+from api.routers import hiscore
 from api.utils import logging_helpers
 
-request_path = f"/discord/get_linked_accounts/{token}/1"
+request_path = f"/v1/hiscore/Latest"
+request_params = {"player_id": 1, "token": token}
+
 
 def test_build_route_log_string(test_client):
     """
@@ -16,8 +18,8 @@ def test_build_route_log_string(test_client):
     gets called with the proper log string passed into it.
     """
 
-    with patch.object(legacy, 'verify_token', return_value=None) as mock:
-        test_client.get(request_path)
+    with patch.object(hiscore, 'verify_token', return_value=None) as mock:
+        test_client.get(request_path, params=request_params)
 
         expected_log_str = '[GET] Path: /discord/get_linked_accounts/***/1 Query Params: '
 
@@ -28,11 +30,11 @@ def test_censor_log_entry():
     Tests if censor_log_entry replaces the specified substrings with '***'
     """
 
-    censored_str = logging_helpers.censor_log_entry(request_path, [token, "discord"])
+    censored_str = logging_helpers.censor_log_entry(request_path, ["Latest", "hiscore"])
 
-    expected_str = "/***/get_linked_accounts/***/1"
+    expected_str = "/v1/***/***"
 
-    assert token not in censored_str
-    assert "discord" not in censored_str
+    assert "hiscore" not in censored_str
+    assert "Latest" not in censored_str
 
     assert censored_str == expected_str

--- a/tests/utils/test_logging_helpers.py
+++ b/tests/utils/test_logging_helpers.py
@@ -5,8 +5,8 @@ from unittest.mock import patch
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from api.Config import token
-from api.database.functions import verify_token
 from api.routers import legacy
+from api.utils import logging_helpers
 
 
 request_path = f"/discord/get_linked_accounts/{token}/1"
@@ -21,8 +21,21 @@ def test_build_route_log_string(test_client):
     with patch.object(legacy, 'verify_token', return_value=None) as mock:
         test_client.get(request_path)
 
-        mock.assert_called_once_with(token, "verify_players", request_path.replace(token, "***"))
+        expected_log_str = '[GET] Path: /discord/get_linked_accounts/***/1 Query Params: '
+
+        mock.assert_called_once_with(token, verification="verify_players", route=expected_log_str)
 
 
-def censor_log_entry():
-    ...
+def test_censor_log_entry():
+    """
+    Tests if censor_log_entry replaces the specified substrings with '***'
+    """
+
+    censored_str = logging_helpers.censor_log_entry(request_path, [token, "discord"])
+
+    expected_str = "/***/get_linked_accounts/***/1"
+
+    assert token not in censored_str
+    assert "discord" not in censored_str
+
+    assert censored_str == expected_str

--- a/tests/utils/test_logging_helpers.py
+++ b/tests/utils/test_logging_helpers.py
@@ -8,9 +8,7 @@ from api.Config import token
 from api.routers import legacy
 from api.utils import logging_helpers
 
-
 request_path = f"/discord/get_linked_accounts/{token}/1"
-
 
 def test_build_route_log_string(test_client):
     """
@@ -24,7 +22,6 @@ def test_build_route_log_string(test_client):
         expected_log_str = '[GET] Path: /discord/get_linked_accounts/***/1 Query Params: '
 
         mock.assert_called_once_with(token, verification="verify_players", route=expected_log_str)
-
 
 def test_censor_log_entry():
     """


### PR DESCRIPTION
# Replace Hard-coded Route Logging Strings

Fixes #446

## Description:

This PR aimed to alleviate the need to manually format and maintain log strings for numerous `verify_token` calls within routes, and to instead allow [Starlette's Request class](https://www.starlette.io/requests/) to handle the heavy lifting.

The `build_route_log_string` method does exactly what it sounds like- it accepts a `Request` object along with a list of strings that you would like to not show up in the logs (tokens, anyone?), and generates a string for the logs. The output will be something similar to as follows:

```python
"[POST] Path: /1.3.2/site/discord_user/*** Query Params: test=true"
```
The `***` portion of the string is a substring that was elected to be censored.

This will allow us to keep the log formatting synchronized across all routes and make it a breeze to adjust it as necessary.

## Other Changes

-  I've added a [conftest.py file](https://docs.pytest.org/en/6.2.x/fixture.html#conftest-py-sharing-fixtures-across-multiple-files) to the Pytest `test` folder and have placed within it a [Pytest fixture](https://docs.pytest.org/en/6.2.x/fixture.html) that provides a [Starlette TestClient ](https://www.starlette.io/testclient/)to any test that requires it. Any fixtures that are defined within conftest.py can be provided as parameters to tests without the need to import conftest.py into that test's file.
- I went through all existing tests and set anything needing a TestClient to use the `test_client` fixture.